### PR TITLE
fix: decode args after skipping unused methods

### DIFF
--- a/indexer-events/src/db_adapters/coin/legacy/aurora.rs
+++ b/indexer-events/src/db_adapters/coin/legacy/aurora.rs
@@ -97,9 +97,6 @@ async fn process_aurora_functions(
         _ => return Ok(vec![]),
     };
 
-    // Note: aurora (now always, but) usually has binary args
-    let decoded_args = base64::decode(args)?;
-
     if vec![
         "new",
         "call",
@@ -119,6 +116,9 @@ async fn process_aurora_functions(
     {
         return Ok(vec![]);
     }
+
+    // Note: aurora (now always, but) usually has binary args
+    let decoded_args = base64::decode(args)?;
 
     // MINT may produce several events, where involved_account_id is always NULL
     // deposit do not mint anything; mint goes in finish_deposit

--- a/indexer-events/src/db_adapters/coin/legacy/rainbow_bridge.rs
+++ b/indexer-events/src/db_adapters/coin/legacy/rainbow_bridge.rs
@@ -94,8 +94,6 @@ async fn process_rainbow_bridge_functions(
         _ => return Ok(vec![]),
     };
 
-    let decoded_args = base64::decode(args)?;
-
     if vec![
         "storage_deposit",
         "finish_deposit",
@@ -109,6 +107,8 @@ async fn process_rainbow_bridge_functions(
     {
         return Ok(vec![]);
     }
+
+    let decoded_args = base64::decode(args)?;
 
     // MINT produces 1 event, where involved_account_id is NULL
     if method_name == "mint" {

--- a/indexer-events/src/db_adapters/coin/legacy/skyward.rs
+++ b/indexer-events/src/db_adapters/coin/legacy/skyward.rs
@@ -72,8 +72,6 @@ async fn process_skyward_functions(
         _ => return Ok(vec![]),
     };
 
-    let decoded_args = base64::decode(args)?;
-
     if vec![
         "storage_deposit",
         "ft_balance_of",
@@ -84,6 +82,8 @@ async fn process_skyward_functions(
     {
         return Ok(vec![]);
     }
+
+    let decoded_args = base64::decode(args)?;
 
     // may mint the tokens
     if method_name == "new" {

--- a/indexer-events/src/db_adapters/coin/legacy/tkn_near.rs
+++ b/indexer-events/src/db_adapters/coin/legacy/tkn_near.rs
@@ -91,8 +91,6 @@ async fn process_tkn_near_functions(
         _ => return Ok(vec![]),
     };
 
-    let decoded_args = base64::decode(args)?;
-
     if vec![
         "storage_deposit",
         "ft_balance_of",
@@ -103,6 +101,8 @@ async fn process_tkn_near_functions(
     {
         return Ok(vec![]);
     }
+
+    let decoded_args = base64::decode(args)?;
 
     // may mint the tokens
     if method_name == "new" {

--- a/indexer-events/src/db_adapters/coin/legacy/wentokensir.rs
+++ b/indexer-events/src/db_adapters/coin/legacy/wentokensir.rs
@@ -90,8 +90,6 @@ async fn process_wentokensir_functions(
         _ => return Ok(vec![]),
     };
 
-    let decoded_args = base64::decode(args)?;
-
     if vec![
         "storage_deposit",
         "new",
@@ -104,6 +102,8 @@ async fn process_wentokensir_functions(
     {
         return Ok(vec![]);
     }
+
+    let decoded_args = base64::decode(args)?;
 
     // MINT produces 1 event, where involved_account_id is NULL
     if method_name == "near_deposit" {

--- a/indexer-events/src/db_adapters/coin/legacy/wrap_near.rs
+++ b/indexer-events/src/db_adapters/coin/legacy/wrap_near.rs
@@ -72,8 +72,6 @@ async fn process_wrap_near_functions(
         _ => return Ok(vec![]),
     };
 
-    let decoded_args = base64::decode(args)?;
-
     if vec![
         "storage_deposit",
         "ft_balance_of",
@@ -85,6 +83,8 @@ async fn process_wrap_near_functions(
     {
         return Ok(vec![]);
     }
+
+    let decoded_args = base64::decode(args)?;
 
     // MINT produces 1 event, where involved_account_id is NULL
     if method_name == "near_deposit" {


### PR DESCRIPTION
It should not affect the work, but aurora has something weird here https://explorer.near.org/transactions/G3FWur1Juk33KiNyuQayAr4THfw4DNXvEmeh7zQsmj6r#FTY6L6B4ivueGEh4uzZTN8xeRSRkyHUopSxj2uteja9E Plus, the new version avoids unnecessary job