### PR TITLE
drop non-blocking IO

### DIFF
--- a/indexer-balances/src/main.rs
+++ b/indexer-balances/src/main.rs
@@ -38,7 +38,7 @@ pub type BalanceCache =
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
     let opts = indexer_opts::Opts::parse();
-    let _worker_guard = configs::init_tracing(opts.debug)?;
+    configs::init_tracing(opts.debug)?;
 
     let rpc_url = opts
         .rpc_url

--- a/indexer-events/src/configs.rs
+++ b/indexer-events/src/configs.rs
@@ -1,12 +1,13 @@
 use tracing_subscriber::EnvFilter;
 
-pub(crate) fn init_tracing(
-    debug: bool,
-) -> anyhow::Result<tracing_appender::non_blocking::WorkerGuard> {
-    let mut env_filter = EnvFilter::new("indexer_events=info,indexer=info");
+pub(crate) fn init_tracing(debug: bool) -> anyhow::Result<()> {
+    let mut env_filter =
+        EnvFilter::new("near_lake_framework=info,indexer_events=info,indexer=info,stats=info");
 
     if debug {
-        env_filter = env_filter.add_directive("near_lake_framework=debug".parse()?);
+        env_filter = env_filter
+            .add_directive("near_lake_framework=debug".parse()?)
+            .add_directive("indexer_events=debug".parse()?);
     }
 
     if let Ok(rust_log) = std::env::var("RUST_LOG") {
@@ -28,11 +29,9 @@ pub(crate) fn init_tracing(
         }
     }
 
-    let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stdout());
-
     let subscriber = tracing_subscriber::fmt::Subscriber::builder()
-        .with_writer(non_blocking)
-        .with_env_filter(env_filter);
+        .with_env_filter(env_filter)
+        .with_writer(std::io::stderr);
 
     if std::env::var("ENABLE_JSON_LOGS").is_ok() {
         subscriber.json().init();
@@ -40,5 +39,5 @@ pub(crate) fn init_tracing(
         subscriber.compact().init();
     }
 
-    Ok(guard)
+    Ok(())
 }

--- a/indexer-events/src/main.rs
+++ b/indexer-events/src/main.rs
@@ -26,7 +26,7 @@ pub struct AccountWithContract {
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
     let opts = indexer_opts::Opts::parse();
-    let _worker_guard = configs::init_tracing(opts.debug)?;
+    configs::init_tracing(opts.debug)?;
 
     let pool = sqlx::PgPool::connect(&opts.database_url).await?;
     let lake_config = opts.to_lake_config(&pool).await?;


### PR DESCRIPTION
We have a theory indexer is stuck from time to time because of this. We have no proofs except the thing indexer-for-explorer does not use non-blocking IO, and it is never stuck.