### PR TITLE
refactor: Process RPC requests in parallel

### DIFF
--- a/indexer-balances/src/main.rs
+++ b/indexer-balances/src/main.rs
@@ -89,6 +89,12 @@ async fn handle_streamer_message(
     pool: &sqlx::Pool<sqlx::Postgres>,
     json_rpc_client: &near_jsonrpc_client::JsonRpcClient,
 ) -> anyhow::Result<u64> {
+    tracing::info!(
+        target: LOGGING_PREFIX,
+        "Processing block {}",
+        streamer_message.block.header.height
+    );
+
     metrics::BLOCK_PROCESSED_TOTAL.inc();
     // Prometheus Gauge Metric type do not support u64
     // https://github.com/tikv/rust-prometheus/issues/470


### PR DESCRIPTION
The volume of account balance (state) changes has increased significantly after the release of Kaiching. Each change requires 1-2 RPC requests, and since all requests are executed sequentially, it has becomes a huge bottleneck for the indexer, causing the blocks per second to fall to ~0.15.

This PR updates `indexer-balances` so that it processes RPC requests in parallel, removing this bottleneck. The two main changes contributing to this update are:
1. Each account state change spawns a new concurrent task (`tokio::spawn`), which is responsible for fetching the relevant data from RPC and returning the `NearBalanceEvent`. This happens for `validator`, `transactions`, `receipts`, and `rewards` events, i.e. everywhere.
2. `BalanceCache`, responsible for caching RPC requests, has been removed as the `Mutex` forced RPC requests to be executed sequentially.

This has resulted in a ~5x increase in block processing speed, which is still less than the rate at which blocks are produced and therefore not enough to work through the existing backlog, but is a step in the right direction.

On the infrastructure side, I've updated `RPC_URL` to `https://beta.rpc.mainnet.near.org`, i.e. [read-rpc](https://github.com/near/read-rpc/), as it is both faster, and more likely to handle the large volume of RPC requests made.

In a follow up PR, I plan to reinstate `BalanceCache` with `RwLock` rather than `Mutex`, so that we can read the cache simultaneously across these concurrent tasks. 