### PR TITLE
refactor: Convert `balance_cache` to `RwLock`

### DIFF
--- a/indexer-balances/src/main.rs
+++ b/indexer-balances/src/main.rs
@@ -1,7 +1,9 @@
 // // TODO cleanup imports in all the files in the end
+use cached::SizedCache;
 use futures::StreamExt;
 use indexer_opts::Parser;
 use near_lake_framework::near_indexer_primitives;
+use tokio::sync::Mutex;
 
 mod configs;
 mod db_adapters;
@@ -29,6 +31,9 @@ pub struct AccountWithBalance {
     pub balance: BalanceDetails,
 }
 
+pub type BalanceCache =
+    std::sync::Arc<Mutex<SizedCache<near_indexer_primitives::types::AccountId, BalanceDetails>>>;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
@@ -48,8 +53,14 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::spawn(metrics::init_server(opts.port).expect("Failed to start metrics server"));
 
+    // We want to prevent unnecessary RPC queries to find previous balance
+    let balances_cache: BalanceCache =
+        std::sync::Arc::new(Mutex::new(SizedCache::with_size(100_000)));
+
     let mut handlers = tokio_stream::wrappers::ReceiverStream::new(stream)
-        .map(|streamer_message| handle_streamer_message(streamer_message, &pool, &json_rpc_client))
+        .map(|streamer_message| {
+            handle_streamer_message(streamer_message, &pool, &balances_cache, &json_rpc_client)
+        })
         .buffer_unordered(1usize);
 
     while let Some(handle_message) = handlers.next().await {
@@ -87,6 +98,7 @@ async fn main() -> anyhow::Result<()> {
 async fn handle_streamer_message(
     streamer_message: near_indexer_primitives::StreamerMessage,
     pool: &sqlx::Pool<sqlx::Postgres>,
+    balances_cache: &BalanceCache,
     json_rpc_client: &near_jsonrpc_client::JsonRpcClient,
 ) -> anyhow::Result<u64> {
     tracing::info!(
@@ -104,6 +116,7 @@ async fn handle_streamer_message(
         pool,
         &streamer_message.shards,
         &streamer_message.block.header,
+        balances_cache,
         json_rpc_client,
     )
     .await?;


### PR DESCRIPTION
This PR is dependant on #42 

This PR adds `balance_cache` back in, but refactors it to use `RwLock` instead of `Mutex`. This is preferred because the former allows multiple read locks, or a single write lock, allowing us to read the cache across all concurrent tasks.

`cached::SizedCache` requires a mutable reference to read from the cache, and therefore can no longer be used, as we would run in to the same issue waiting for a single lock. I've replaced this with a `HashMap` for now, which means the **cache will grow unbounded**. I'll monitor application memory and can add some sort of eviction policy if needed.

Previously, we would cache the RPC result right after it succeeded. As RPC requests are executed concurrently, this is no longer possible. Instead, the cache is now updated after the chunk has been processed, i.e. after all RPC requests have been made.

I'm not sure if that last point has any impact on the output data, i.e. are we storing, or accessing, the wrong data as we have changed when the cache is updated? I'll dump the output prior to this change and compare it with the output now to confirm.