### PR TITLE
refactor: Introduce CLI flag to toggle between DB/RPC balance fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,13 +348,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.66"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2336,6 +2336,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "anyhow",
+ "async-trait",
  "bigdecimal",
  "cached",
  "dotenv",
@@ -3347,9 +3348,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -3430,9 +3431,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -3806,7 +3807,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -4162,9 +4163,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4229,7 +4230,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -148,3 +148,13 @@ This solution stores all the creations/deletions, so accounts may appear in the 
 
 We use `indexer-balances` in production; we use FT part of `indexer-events` in production as well.  
 The other pieces are frozen for now, they need to be upgraded and reviewed before any production usage.
+
+### What is "Balance Mode" for `indexer-balances`
+
+`indexer-balances` requires the Near balance prior to the current block in order to calculate, and store, the delta. Previously, this value was fetched directly from JSON RPC, but as transaction volume increased, this method became a bottleneck within the application. A more performant approach is to fetch the previously stored balance from the DB, but this also comes with drawbacks. In summary:
+- `DB` - Performant, but potentially more error prone as incorrect deltas propagate to deltas following
+- `RPC` - Less performant, but also less error prone as the deltas rely on actual on-chain balances
+
+Additionally, as `DB` relies on existing data, it can not be started from any arbitrary block, it requires the all blocks prior have already been indexed. The limitation does not exist for `RPC`.
+
+The `--balance-mode` flag allows switching between the described methods so that the trade-offs can be more effectively managed.

--- a/indexer-balances/Cargo.toml
+++ b/indexer-balances/Cargo.toml
@@ -9,6 +9,7 @@ proc-macro = true
 
 [dependencies]
 actix-web = "=4.0.1"
+async-trait = "0.1.74"
 anyhow = "1.0.51"
 bigdecimal = { version = "0.2", features = ["serde"] }
 cached = "0.23.0"

--- a/indexer-balances/src/balance_client.rs
+++ b/indexer-balances/src/balance_client.rs
@@ -1,0 +1,54 @@
+use std::str::FromStr;
+
+use crate::models::balance_changes::NearBalanceEvent;
+use crate::models::SqlxMethods;
+use async_trait::async_trait;
+use near_lake_framework::near_indexer_primitives;
+
+#[async_trait]
+pub trait BalanceClient {
+    async fn get_balance_before_block(
+        &self,
+        account_id: &near_indexer_primitives::types::AccountId,
+        block_header: &near_indexer_primitives::views::BlockHeaderView,
+    ) -> anyhow::Result<crate::BalanceDetails>;
+}
+
+pub struct PgBalanceClient {
+    pool: sqlx::Pool<sqlx::Postgres>,
+}
+
+impl PgBalanceClient {
+    pub fn new(pool: sqlx::Pool<sqlx::Postgres>) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl BalanceClient for PgBalanceClient {
+    async fn get_balance_before_block(
+        &self,
+        account_id: &near_indexer_primitives::types::AccountId,
+        block_header: &near_indexer_primitives::views::BlockHeaderView,
+    ) -> anyhow::Result<crate::BalanceDetails> {
+        let account_balance = match crate::models::select_one_retry_or_panic(
+            &self.pool,
+            &NearBalanceEvent::select_prev_balance_query(block_header.height, account_id),
+            crate::RETRY_COUNT,
+        )
+        .await
+        {
+            Ok(Some(balance_event)) => crate::BalanceDetails {
+                non_staked: u128::from_str(&balance_event.absolute_nonstaked_amount.to_string())?,
+                staked: u128::from_str(&balance_event.absolute_staked_amount.to_string())?,
+            },
+            Ok(None) => crate::BalanceDetails {
+                non_staked: 0,
+                staked: 0,
+            },
+            Err(e) => anyhow::bail!(e),
+        };
+
+        Ok(account_balance)
+    }
+}

--- a/indexer-balances/src/balance_client.rs
+++ b/indexer-balances/src/balance_client.rs
@@ -14,6 +14,66 @@ pub trait BalanceClient {
     ) -> anyhow::Result<crate::BalanceDetails>;
 }
 
+pub struct JsonRpcBalanceClient {
+    json_rpc_client: near_jsonrpc_client::JsonRpcClient,
+}
+
+impl JsonRpcBalanceClient {
+    pub fn new(json_rpc_client: near_jsonrpc_client::JsonRpcClient) -> Self {
+        Self { json_rpc_client }
+    }
+}
+
+#[async_trait]
+impl BalanceClient for JsonRpcBalanceClient {
+    async fn get_balance_before_block(
+        &self,
+        account_id: &near_indexer_primitives::types::AccountId,
+        block_header: &near_indexer_primitives::views::BlockHeaderView,
+    ) -> anyhow::Result<crate::BalanceDetails> {
+        let query = near_jsonrpc_client::methods::query::RpcQueryRequest {
+            block_reference: near_primitives::types::BlockReference::BlockId(
+                near_primitives::types::BlockId::Hash(block_header.prev_hash),
+            ),
+            request: near_primitives::views::QueryRequest::ViewAccount {
+                account_id: account_id.clone(),
+            },
+        };
+
+        let account_response = self.json_rpc_client.call(query).await;
+
+        if let Err(err) = account_response {
+            return match err.handler_error() {
+                Some(near_jsonrpc_primitives::types::query::RpcQueryError::UnknownAccount {
+                    ..
+                }) => Ok(crate::BalanceDetails {
+                    non_staked: 0,
+                    staked: 0,
+                }),
+                _ => Err(err.into()),
+            };
+        }
+
+        let response_kind = account_response.unwrap().kind;
+
+        match response_kind {
+            near_jsonrpc_primitives::types::query::QueryResponseKind::ViewAccount(account) => {
+                Ok(crate::BalanceDetails {
+                    non_staked: account.amount,
+                    staked: account.locked,
+                })
+            }
+            _ => unreachable!(
+                "Unreachable code! Asked for ViewAccount (block_id {:?}, account_id {})\nReceived\n\
+                {:#?}\nReport this to https://github.com/near/near-jsonrpc-client-rs",
+                block_header.prev_hash,
+                account_id.to_string(),
+                response_kind
+            ),
+        }
+    }
+}
+
 pub struct PgBalanceClient {
     pool: sqlx::Pool<sqlx::Postgres>,
 }

--- a/indexer-balances/src/balance_client.rs
+++ b/indexer-balances/src/balance_client.rs
@@ -54,7 +54,7 @@ impl BalanceClient for JsonRpcBalanceClient {
             };
         }
 
-        let response_kind = account_response.unwrap().kind;
+        let response_kind = account_response?.kind;
 
         match response_kind {
             near_jsonrpc_primitives::types::query::QueryResponseKind::ViewAccount(account) => {

--- a/indexer-balances/src/cache.rs
+++ b/indexer-balances/src/cache.rs
@@ -1,0 +1,35 @@
+use cached::{Cached, SizedCache};
+
+use near_lake_framework::near_indexer_primitives;
+use tokio::sync::Mutex;
+
+pub struct BalanceCache {
+    cache: std::sync::Arc<
+        Mutex<SizedCache<near_indexer_primitives::types::AccountId, crate::BalanceDetails>>,
+    >,
+}
+
+impl BalanceCache {
+    pub fn new(size: usize) -> Self {
+        Self {
+            cache: std::sync::Arc::new(Mutex::new(SizedCache::with_size(size))),
+        }
+    }
+
+    pub async fn get(
+        &self,
+        account_id: &near_indexer_primitives::types::AccountId,
+    ) -> Option<crate::BalanceDetails> {
+        let mut lock = self.cache.lock().await;
+        lock.cache_get(account_id).copied()
+    }
+
+    pub async fn set(
+        &self,
+        account_id: &near_indexer_primitives::types::AccountId,
+        balance: crate::BalanceDetails,
+    ) {
+        let mut lock = self.cache.lock().await;
+        lock.cache_set(account_id.clone(), balance);
+    }
+}

--- a/indexer-balances/src/db_adapters/balance_changes.rs
+++ b/indexer-balances/src/db_adapters/balance_changes.rs
@@ -202,7 +202,7 @@ async fn store_validator_accounts_update_for_chunk(
 ) -> anyhow::Result<Vec<NearBalanceEvent>> {
     let mut result: Vec<NearBalanceEvent> = vec![];
     for new_details in validator_changes {
-        let prev_balance = get_balance(
+        let prev_balance = get_balance_before_block(
             &new_details.account_id,
             block_header.height,
             balances_cache,
@@ -260,7 +260,7 @@ async fn store_transaction_execution_outcomes_for_chunk(
             _ => Some(&transaction.transaction.receiver_id),
         };
 
-        let prev_balance = get_balance(
+        let prev_balance = get_balance_before_block(
             affected_account_id,
             block_header.height,
             balances_cache,
@@ -325,7 +325,8 @@ async fn store_transaction_execution_outcomes_for_chunk(
             if account_id != affected_account_id {
                 // balance is not changing here, we just note the line here
                 let balance =
-                    get_balance(account_id, block_header.height, balances_cache, pool).await?;
+                    get_balance_before_block(account_id, block_header.height, balances_cache, pool)
+                        .await?;
 
                 result.push(NearBalanceEvent {
                     event_index: BigDecimal::zero(), // will enumerate later
@@ -398,7 +399,7 @@ async fn store_receipt_execution_outcomes_for_chunk(
             );
             }
 
-            let prev_balance = get_balance(
+            let prev_balance = get_balance_before_block(
                 affected_account_id,
                 block_header.height,
                 balances_cache,
@@ -443,8 +444,13 @@ async fn store_receipt_execution_outcomes_for_chunk(
             if let Some(account_id) = involved_account_id {
                 if account_id != affected_account_id {
                     // balance is not changing here, we just note the line here
-                    let balance =
-                        get_balance(account_id, block_header.height, balances_cache, pool).await?;
+                    let balance = get_balance_before_block(
+                        account_id,
+                        block_header.height,
+                        balances_cache,
+                        pool,
+                    )
+                    .await?;
 
                     result.push(NearBalanceEvent {
                         event_index: BigDecimal::zero(), // will enumerate later
@@ -486,7 +492,7 @@ async fn store_receipt_execution_outcomes_for_chunk(
             );
             }
 
-            let prev_balance = get_balance(
+            let prev_balance = get_balance_before_block(
                 affected_account_id,
                 block_header.height,
                 balances_cache,
@@ -560,7 +566,7 @@ fn get_deltas(
     ))
 }
 
-async fn get_balance(
+async fn get_balance_before_block(
     account_id: &near_indexer_primitives::types::AccountId,
     block_height: u64,
     balance_cache: &cache::BalanceCache,

--- a/indexer-balances/src/db_adapters/balance_changes.rs
+++ b/indexer-balances/src/db_adapters/balance_changes.rs
@@ -21,7 +21,7 @@ pub(crate) async fn store_balance_changes(
     shards: &[near_indexer_primitives::IndexerShard],
     block_header: &near_indexer_primitives::views::BlockHeaderView,
     balances_cache: &cache::BalanceCache,
-    balance_client: &impl crate::balance_client::BalanceClient,
+    balance_client: &dyn crate::balance_client::BalanceClient,
 ) -> anyhow::Result<()> {
     let futures = shards.iter().map(|shard| {
         store_changes_for_chunk(pool, shard, block_header, balances_cache, balance_client)
@@ -43,7 +43,7 @@ async fn store_changes_for_chunk(
     shard: &near_indexer_primitives::IndexerShard,
     block_header: &near_indexer_primitives::views::BlockHeaderView,
     balances_cache: &cache::BalanceCache,
-    balance_client: &impl crate::balance_client::BalanceClient,
+    balance_client: &dyn crate::balance_client::BalanceClient,
 ) -> anyhow::Result<()> {
     let mut changes: Vec<NearBalanceEvent> = vec![];
     let mut changes_data =
@@ -200,7 +200,7 @@ async fn store_validator_accounts_update_for_chunk(
     validator_changes: &[crate::AccountWithBalance],
     block_header: &near_indexer_primitives::views::BlockHeaderView,
     balances_cache: &cache::BalanceCache,
-    balance_client: &impl crate::balance_client::BalanceClient,
+    balance_client: &dyn crate::balance_client::BalanceClient,
 ) -> anyhow::Result<Vec<NearBalanceEvent>> {
     let mut result: Vec<NearBalanceEvent> = vec![];
     for new_details in validator_changes {
@@ -251,7 +251,7 @@ async fn store_transaction_execution_outcomes_for_chunk(
     >,
     block_header: &near_indexer_primitives::views::BlockHeaderView,
     balances_cache: &cache::BalanceCache,
-    balance_client: &impl crate::balance_client::BalanceClient,
+    balance_client: &dyn crate::balance_client::BalanceClient,
 ) -> anyhow::Result<Vec<NearBalanceEvent>> {
     let mut result: Vec<NearBalanceEvent> = vec![];
 
@@ -382,7 +382,7 @@ async fn store_receipt_execution_outcomes_for_chunk(
     reward_changes: &mut HashMap<near_indexer_primitives::CryptoHash, crate::AccountWithBalance>,
     block_header: &near_indexer_primitives::views::BlockHeaderView,
     balances_cache: &cache::BalanceCache,
-    balance_client: &impl crate::balance_client::BalanceClient,
+    balance_client: &dyn crate::balance_client::BalanceClient,
 ) -> anyhow::Result<Vec<NearBalanceEvent>> {
     let mut result: Vec<NearBalanceEvent> = vec![];
 
@@ -576,7 +576,7 @@ async fn get_balance_before_block(
     account_id: &near_indexer_primitives::types::AccountId,
     block_header: &near_indexer_primitives::views::BlockHeaderView,
     balance_cache: &cache::BalanceCache,
-    balance_client: &impl crate::balance_client::BalanceClient,
+    balance_client: &dyn crate::balance_client::BalanceClient,
 ) -> anyhow::Result<crate::BalanceDetails> {
     if let Some(balance) = balance_cache.get(account_id).await {
         return Ok(balance);

--- a/indexer-balances/src/main.rs
+++ b/indexer-balances/src/main.rs
@@ -1,10 +1,9 @@
 // // TODO cleanup imports in all the files in the end
-use cached::SizedCache;
 use futures::StreamExt;
 use indexer_opts::Parser;
 use near_lake_framework::near_indexer_primitives;
-use tokio::sync::Mutex;
 
+mod cache;
 mod configs;
 mod db_adapters;
 mod metrics;
@@ -31,9 +30,6 @@ pub struct AccountWithBalance {
     pub balance: BalanceDetails,
 }
 
-pub type BalanceCache =
-    std::sync::Arc<Mutex<SizedCache<near_indexer_primitives::types::AccountId, BalanceDetails>>>;
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
@@ -53,9 +49,7 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::spawn(metrics::init_server(opts.port).expect("Failed to start metrics server"));
 
-    // We want to prevent unnecessary RPC queries to find previous balance
-    let balances_cache: BalanceCache =
-        std::sync::Arc::new(Mutex::new(SizedCache::with_size(100_000)));
+    let balances_cache = cache::BalanceCache::new(100_000);
 
     let mut handlers = tokio_stream::wrappers::ReceiverStream::new(stream)
         .map(|streamer_message| {
@@ -98,7 +92,7 @@ async fn main() -> anyhow::Result<()> {
 async fn handle_streamer_message(
     streamer_message: near_indexer_primitives::StreamerMessage,
     pool: &sqlx::Pool<sqlx::Postgres>,
-    balances_cache: &BalanceCache,
+    balances_cache: &cache::BalanceCache,
     json_rpc_client: &near_jsonrpc_client::JsonRpcClient,
 ) -> anyhow::Result<u64> {
     metrics::BLOCK_PROCESSED_TOTAL.inc();

--- a/indexer-balances/src/main.rs
+++ b/indexer-balances/src/main.rs
@@ -203,6 +203,11 @@ async fn handle_streamer_message(
     balances_cache: &cache::BalanceCache,
     balance_client: &impl BalanceClient,
 ) -> anyhow::Result<u64> {
+    tracing::info!(
+        target: LOGGING_PREFIX,
+        "Processing block: {}",
+        streamer_message.block.header.height
+    );
     metrics::BLOCK_PROCESSED_TOTAL.inc();
     // Prometheus Gauge Metric type do not support u64
     // https://github.com/tikv/rust-prometheus/issues/470

--- a/indexer-balances/src/metrics.rs
+++ b/indexer-balances/src/metrics.rs
@@ -30,6 +30,21 @@ lazy_static! {
         "Last seen block height by indexer"
     )
     .unwrap();
+    pub(crate) static ref CACHE_HITS: IntGauge = try_create_int_gauge(
+        "indexer_balances_cache_hits",
+        "total cache hits",
+    )
+    .unwrap();
+    pub(crate) static ref CACHE_MISSES: IntGauge = try_create_int_gauge(
+        "indexer_balances_cache_misses",
+        "total cache misses",
+    )
+    .unwrap();
+    pub(crate) static ref CACHE_SIZE: IntGauge = try_create_int_gauge(
+        "indexer_balances_cache_size",
+        "total cache size",
+    )
+    .unwrap();
 }
 
 #[get("/metrics")]

--- a/indexer-balances/src/models/balance_changes.rs
+++ b/indexer-balances/src/models/balance_changes.rs
@@ -3,7 +3,7 @@ use sqlx::Arguments;
 
 use crate::models::FieldCount;
 
-#[derive(Debug, sqlx::FromRow, FieldCount)]
+#[derive(Debug, sqlx::FromRow, FieldCount, PartialEq)]
 pub struct NearBalanceEvent {
     pub event_index: BigDecimal,
     pub block_timestamp: BigDecimal,

--- a/indexer-balances/src/models/balance_changes.rs
+++ b/indexer-balances/src/models/balance_changes.rs
@@ -45,6 +45,20 @@ impl crate::models::SqlxMethods for NearBalanceEvent {
             + " ON CONFLICT DO NOTHING")
     }
 
+    fn select_prev_balance_query(block_height: u64, account_id: &str) -> String {
+        format!(
+            "
+                 SELECT *
+                 FROM near_balance_events
+                 WHERE block_height < {}
+                 AND affected_account_id = '{}'
+                 ORDER BY event_index desc
+                 LIMIT 1;
+             ",
+            block_height, account_id
+        )
+    }
+
     fn name() -> String {
         "near_balance_events".to_string()
     }

--- a/indexer-balances/src/models/mod.rs
+++ b/indexer-balances/src/models/mod.rs
@@ -57,8 +57,8 @@ pub(crate) async fn select_one_retry_or_panic(
         {
             Ok(res) => return Ok(res),
             Err(async_error) => {
-                println!(
-                    // target: crate::LOGGING_PREFIX,
+                tracing::info!(
+                    target: crate::LOGGING_PREFIX,
                     "Error occurred during {}:\nFailed SELECT: {}\n Retrying in {} milliseconds...",
                     async_error,
                     query,

--- a/indexer-opts/src/lib.rs
+++ b/indexer-opts/src/lib.rs
@@ -49,6 +49,17 @@ pub struct Opts {
     /// Database URL
     #[clap(long, short, env)]
     pub database_url: String,
+    /// How NEAR balances, which are used to calculate deltas, should be fetched, either from JSON
+    /// RPC or from the database. This is only applicable for the `indexer-balances` micro-indexer
+    #[clap(long, env, arg_enum, default_value = "db")]
+    pub balance_mode: BalanceMode,
+}
+
+/// Represents the type of balance fetching mode
+#[derive(ArgEnum, Debug, Clone, PartialEq, Eq)]
+pub enum BalanceMode {
+    DB,
+    RPC,
 }
 
 /// Represents the chain-id variants for indexer to stream from


### PR DESCRIPTION
The main bottleneck for `indexer-balances` are the RPC requests which take around ~400ms per call. This PR replaces the RPC call with a request to Postgres which takes only ~10ms. This significantly increases the BPS allowing us to handle the recent increase in transaction load coming from Kaiching.

The downside to this approach is that incorrect data in the DB will continue to compound, as new balances are dependant on previous balances. With RPC we'd always fetch the 'correct' balance, so incorrect calculations would only affect that block. Due to the latency RPC produces, this is a trade-off we have to make, i.e. processing speed vs. potentially incorrectness. If this becomes more of a concern we can introduce an external system which does random checks against RPC.

The cache is still used to store intermediate changes within a block, this PR only replaces the call to fetch balances which don't exist in cache, i.e. have not yet been seen by the indexer.